### PR TITLE
Fix some font information

### DIFF
--- a/Source/Monoid-Bold.sfdir/font.props
+++ b/Source/Monoid-Bold.sfdir/font.props
@@ -18,6 +18,7 @@ Layer: 2 0 "Back 2" 1
 Layer: 3 0 "Back 3" 1
 PreferredKerning: 4
 XUID: [1021 365 -928128380 13773435]
+StyleMap: 0x0020
 FSType: 0
 OS2Version: 4
 OS2_WeightWidthSlopeOnly: 0
@@ -29,6 +30,7 @@ TTFWeight: 700
 TTFWidth: 4
 LineGap: 0
 VLineGap: 184
+Panose: 2 11 8 9 2 2 4 2 2 4
 OS2TypoAscent: 1664
 OS2TypoAOffset: 0
 OS2TypoDescent: -384

--- a/Source/Monoid-Italic.sfdir/font.props
+++ b/Source/Monoid-Italic.sfdir/font.props
@@ -18,6 +18,7 @@ Layer: 1 0 "Fore" 0
 Layer: 2 0 "Back 2" 1
 PreferredKerning: 4
 XUID: [1021 365 -928128380 13773435]
+StyleMap: 0x0001
 FSType: 0
 OS2Version: 4
 OS2_WeightWidthSlopeOnly: 0
@@ -29,7 +30,7 @@ TTFWeight: 400
 TTFWidth: 4
 LineGap: 0
 VLineGap: 184
-Panose: 2 11 5 9 4 0 0 2 0 4
+Panose: 2 11 5 9 2 2 4 9 2 4
 OS2TypoAscent: 1664
 OS2TypoAOffset: 0
 OS2TypoDescent: -384

--- a/Source/Monoid-Retina.sfdir/font.props
+++ b/Source/Monoid-Retina.sfdir/font.props
@@ -19,6 +19,7 @@ Layer: 3 0 "Back 3" 1
 Layer: 4 0 "Back 4" 1
 PreferredKerning: 4
 XUID: [1021 365 -928128380 13773435]
+StyleMap: 0x0040
 FSType: 0
 OS2Version: 4
 OS2_WeightWidthSlopeOnly: 0
@@ -30,6 +31,7 @@ TTFWeight: 300
 TTFWidth: 4
 LineGap: 0
 VLineGap: 184
+Panose: 2 11 4 9 2 2 4 2 2 4
 OS2TypoAscent: 1664
 OS2TypoAOffset: 0
 OS2TypoDescent: -384

--- a/Source/Monoid.sfdir/font.props
+++ b/Source/Monoid.sfdir/font.props
@@ -19,6 +19,7 @@ Layer: 3 0 "Back 3" 1
 Layer: 4 0 "Back 4" 1
 PreferredKerning: 4
 XUID: [1021 365 -928128380 13773435]
+StyleMap: 0x0040
 FSType: 0
 OS2Version: 4
 OS2_WeightWidthSlopeOnly: 0
@@ -30,7 +31,7 @@ TTFWeight: 400
 TTFWidth: 4
 LineGap: 0
 VLineGap: 184
-Panose: 2 11 5 9 4 0 0 2 0 4
+Panose: 2 11 5 9 2 2 4 2 2 4
 OS2TypoAscent: 1664
 OS2TypoAOffset: 0
 OS2TypoDescent: -384


### PR DESCRIPTION
Fixes (hopefully) issue 121 and adjusts these Panose values (using http://monotype.de/services/pan2 as a reference): Contrast=None, Stroke Variation=No Variation, Arm Style=Straight Arms/Vertical, Midline=Standard/Trimmed
